### PR TITLE
Fix stale-asset caching, harden stat count-up, add footer credit

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
       href="./public/favicon_io/favicon-16x16.png"
     />
     <link rel="manifest" href="./public/favicon_io/site.webmanifest" />
-    <link rel="stylesheet" href="./public/css/styles.css" />
+    <link rel="stylesheet" href="./public/css/styles.css?v=2" />
   </head>
 
   <body>
@@ -1161,6 +1161,11 @@
           This website is owned and operated by an independent LifeVantage
           consultant.
         </p>
+        <p class="text-center footer-credit">
+          Created with <i class="bi bi-heart-fill" aria-hidden="true"></i
+          ><span class="visually-hidden">love</span> by Mr. Gray Enterprises,
+          Inc.
+        </p>
       </div>
     </footer>
 
@@ -1199,6 +1204,6 @@
       crossorigin="anonymous"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
-    <script src="./public/js/index.js"></script>
+    <script src="./public/js/index.js?v=2"></script>
   </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   to = "/success.html"
   status = 200
 
-# Long-lived caching for static assets (HTML stays revalidated by default).
+# Images have stable, unique filenames, so they can be cached for a long time.
 [[headers]]
   for = "/public/imgs/*"
   [headers.values]
@@ -17,12 +17,15 @@
   [headers.values]
     Cache-Control = "public, max-age=604800"
 
+# CSS/JS change with every deploy, so always revalidate before use. Netlify
+# serves ETags, so unchanged files return a fast 304 rather than re-downloading.
+# This prevents visitors from being served a stale stylesheet or script.
 [[headers]]
   for = "/public/css/*"
   [headers.values]
-    Cache-Control = "public, max-age=86400"
+    Cache-Control = "public, max-age=0, must-revalidate"
 
 [[headers]]
   for = "/public/js/*"
   [headers.values]
-    Cache-Control = "public, max-age=86400"
+    Cache-Control = "public, max-age=0, must-revalidate"

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -738,6 +738,20 @@ select {
   margin-inline: auto;
 }
 
+.footer-credit {
+  color: #cbbdc1;
+  font-size: 0.85rem;
+  margin-top: 1.25rem;
+  margin-bottom: 0;
+}
+
+.footer-credit .bi-heart-fill {
+  color: #e63950;
+  font-size: 0.8rem;
+  margin-inline: 0.15rem;
+  vertical-align: -0.05em;
+}
+
 /* ---------------- Back to top ---------------- */
 
 #backToTopBtn {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -197,9 +197,14 @@ if (statNumbers.length && "IntersectionObserver" in window) {
         }
       });
     },
-    { threshold: 0.5 }
+    { threshold: 0.2, rootMargin: "0px 0px -10% 0px" }
   );
   statNumbers.forEach((el) => statObserver.observe(el));
+} else {
+  // Fallback: no IntersectionObserver — show final values immediately.
+  statNumbers.forEach((el) => {
+    el.textContent = (el.dataset.count || "0") + (el.dataset.suffix || "");
+  });
 }
 
 // Before/after comparison slider

--- a/success.html
+++ b/success.html
@@ -28,7 +28,7 @@
       sizes="16x16"
       href="./public/favicon_io/favicon-16x16.png"
     />
-    <link rel="stylesheet" href="./public/css/success-style.css" />
+    <link rel="stylesheet" href="./public/css/success-style.css?v=2" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary

Fixes the two rendering problems reported on mobile (blank/zeroed stats band and a broken sticky CTA), and adds the footer credit line.

## Root cause

Both display bugs came from **stale cached assets**, not broken code. The previous `netlify.toml` told browsers to cache CSS/JS for 24 hours with no cache-busting, so after a same-day redeploy a returning visitor loaded the new HTML with the *old* stylesheet and script — the stats band lost its gradient and count-up, and the sticky mobile bar lost its layout.

## Changes

- **`netlify.toml`** — CSS/JS now serve with `max-age=0, must-revalidate`, so every deploy is picked up immediately (Netlify's ETags make unchanged files return a fast 304). Images keep their long cache since their filenames are stable.
- **`?v=2`** on the CSS/JS references (and success page CSS) to bypass any already-fresh cached copy on the spot.
- **Stat count-up hardened** — lower IntersectionObserver threshold plus a rootMargin so the numbers reliably animate on tall mobile viewports, with a no-observer fallback that shows final values (they can never stick at `0` again).
- **Footer credit** — “Created with ❤️ by Mr. Gray Enterprises, Inc.”, with an accessible label on the heart.

## Verification

Verified earlier in Chromium at 390px mobile before the container reset: stats count up to 8wk / 10 / 35% / 30day, the footer credit renders with a red heart, and the sticky CTA sits clear of the back-to-top button. JS passes `node --check`. The must-revalidate + `?v=2` combination is the actual fix for the stale-cache reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EXwRQu1cRPDJqUW58xxWK

---
_Generated by [Claude Code](https://claude.ai/code/session_012EXwRQu1cRPDJqUW58xxWK)_