### PR TITLE
Rework section headings and rebuild logo as a text wordmark

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,12 +146,10 @@
   <body>
     <nav class="navbar navbar-expand-lg fixed-top site-navbar">
       <div class="container">
-        <a class="navbar-brand" href="#top">
-          <img
-            id="logo"
-            src="./public/imgs/activated-glow-logo.png"
-            alt="Activated Glow logo"
-          />
+        <a class="navbar-brand brand-wordmark" href="#top" aria-label="Activated Glow home">
+          <span class="brand-activated">Activated</span>
+          <span class="brand-glow">Glow</span>
+          <span class="brand-spark" aria-hidden="true">&#10022;</span>
         </a>
         <button
           class="navbar-toggler"
@@ -310,7 +308,7 @@
     <section class="ingredients section" id="ingredients">
       <div class="container">
         <h2 class="text-center section-heading">
-          What's In It and How Does It Work?
+          What's Inside &amp; How It Works
         </h2>
         <hr class="section-rule" />
         <div class="row g-4">
@@ -408,7 +406,7 @@
 
     <section class="featured-products section" id="featured-products">
       <div class="container">
-        <h2 class="text-center section-heading">Featured Products</h2>
+        <h2 class="text-center section-heading">Shop the Glow</h2>
         <hr class="section-rule" />
         <div class="row g-4">
           <div class="col-md-6" data-aos="fade-up">
@@ -495,7 +493,7 @@
 
     <section class="comparison section" id="comparison">
       <div class="container">
-        <h2 class="text-center section-heading">Science &amp; Comparison</h2>
+        <h2 class="text-center section-heading">Backed by Science</h2>
         <hr class="section-rule" />
         <div class="row g-4 align-items-stretch">
           <div class="col-md-4" data-aos="fade-up">
@@ -554,7 +552,7 @@
 
     <section class="photo-gallery section" id="photo-gallery">
       <div class="container">
-        <h2 class="text-center section-heading">Before &amp; After Photos</h2>
+        <h2 class="text-center section-heading">Real Results</h2>
         <hr class="section-rule" />
         <div class="row justify-content-center mb-5">
           <div class="col-lg-7 col-md-9" data-aos="fade-up">
@@ -604,7 +602,7 @@
 
     <section class="testimonials section" id="testimonials">
       <div class="container">
-        <h2 class="text-center section-heading">Testimonials</h2>
+        <h2 class="text-center section-heading">Glowing Reviews</h2>
         <hr class="section-rule" />
         <div class="row g-4" id="testimonial-grid"></div>
         <h3 class="customer-posts-heading text-center">
@@ -621,7 +619,7 @@
     <section class="consultants section" id="consultants">
       <div class="container">
         <h2 class="text-center section-heading">
-          Become a Product Consultant
+          Turn Your Glow Into Income
         </h2>
         <hr class="section-rule" />
         <div class="row g-4 align-items-center">
@@ -731,7 +729,7 @@
 
     <section class="influencers section" id="influencers">
       <div class="container">
-        <h2 class="text-center section-heading">Are You An Influencer?</h2>
+        <h2 class="text-center section-heading">Calling All Influencers</h2>
         <hr class="section-rule" />
         <div class="row g-4 align-items-center">
           <div class="col-lg-6 order-lg-2" data-aos="fade-up">
@@ -827,7 +825,7 @@
 
     <section class="why section" id="why">
       <div class="container">
-        <h2 class="text-center section-heading">Why Do You Need Collagen?</h2>
+        <h2 class="text-center section-heading">Why Collagen Matters</h2>
         <hr class="section-rule" />
         <div class="row g-4 align-items-center">
           <div class="col-lg-6" data-aos="fade-up">
@@ -1101,7 +1099,7 @@
 
     <section class="resource section" id="resources">
       <div class="container">
-        <h2 class="text-center section-heading">Additional Resources</h2>
+        <h2 class="text-center section-heading">The Research</h2>
         <hr class="section-rule" />
         <div class="row g-3">
           <div class="col-md-4 doc-links">

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -75,9 +75,66 @@ select {
   padding-bottom: 0.5rem;
 }
 
-#logo {
-  height: 44px;
-  width: auto;
+/* Text wordmark logo */
+.brand-wordmark {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  text-decoration: none;
+  font-size: 1.55rem;
+  line-height: 1;
+  padding-block: 0.1rem;
+}
+
+.brand-activated {
+  font-family: var(--font-body);
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: 0.005em;
+}
+
+.brand-glow {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-style: italic;
+  background: linear-gradient(95deg, var(--brand) 0%, var(--brand-dark) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.brand-spark {
+  align-self: flex-start;
+  font-size: 0.62em;
+  color: var(--brand);
+  margin-left: -0.12rem;
+  text-shadow: 0 0 10px rgba(255, 84, 106, 0.55);
+  animation: sparkTwinkle 3.5s ease-in-out infinite;
+}
+
+@keyframes sparkTwinkle {
+  0%,
+  100% {
+    opacity: 0.6;
+    transform: scale(0.92);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+}
+
+@media (max-width: 400px) {
+  .brand-wordmark {
+    font-size: 1.3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .brand-spark {
+    animation: none;
+  }
 }
 
 .site-navbar .nav-link {


### PR DESCRIPTION
## Summary

Reworks the section headings and rebuilds the top-left logo.

## Logo

Replaced the flat PNG (two words in a plain system font, washed-out pink) with a **crisp CSS text wordmark**: "Activated" in clean sans, "Glow" in italic Playfair with a pink→rose gradient, and a small twinkling spark accent. It scales sharply at any size, matches the site's Inter/Playfair type system, and carries the same glow feel as the hero. Single-line, fits cleanly next to the mobile hamburger.

## Section headings

Swapped the generic, noun-y headings for on-brand, benefit-led copy with a consistent "glow" thread:

| Before | After |
|---|---|
| What's In It and How Does It Work? | What's Inside & How It Works |
| Featured Products | Shop the Glow |
| Science & Comparison | Backed by Science |
| Before & After Photos | Real Results |
| Testimonials | Glowing Reviews |
| Become a Product Consultant | Turn Your Glow Into Income |
| Are You An Influencer? | Calling All Influencers |
| Why Do You Need Collagen? | Why Collagen Matters |
| Additional Resources | The Research |

The FAQ heading is kept as "Frequently Asked Questions" to stay aligned with the FAQ structured data.

## Verification

Verified in Chromium at desktop (1400px) and mobile (390px): the wordmark renders with its gradient and spark and fits the navbar at both sizes, all ten headings render the new text, no console errors, no 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EXwRQu1cRPDJqUW58xxWK

---
_Generated by [Claude Code](https://claude.ai/code/session_012EXwRQu1cRPDJqUW58xxWK)_